### PR TITLE
feat(stats): add time-range filtering for latency and endpoint metrics

### DIFF
--- a/logs/app.log
+++ b/logs/app.log
@@ -1,0 +1,3 @@
+INFO 2025-09-10 10:12:33 /api/login Request processed in 120ms
+ERROR 2025-09-10 10:12:35 /api/data Timeout after 5000ms
+INFO 2025-09-10 10:12:37 /api/home Request processed in 80ms

--- a/src/main/java/com/harshal/logs/log_processor/LogProcessorApplication.java
+++ b/src/main/java/com/harshal/logs/log_processor/LogProcessorApplication.java
@@ -2,8 +2,11 @@ package com.harshal.logs.log_processor;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling  // 👈 this enables @Scheduled tasks
+
 public class LogProcessorApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/harshal/logs/log_processor/ingest/LogFileReader.java
+++ b/src/main/java/com/harshal/logs/log_processor/ingest/LogFileReader.java
@@ -1,0 +1,84 @@
+package com.harshal.logs.log_processor.ingest;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.harshal.logs.log_processor.model.LogEntry;
+import com.harshal.logs.log_processor.service.LogService;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class LogFileReader {
+    private final LogService service;
+    private long lastKnownPosition = 0; // keep track of where we left off
+    private static final String LOG_FILE_PATH = "logs/app.log";
+
+    public LogFileReader(LogService service) {
+        this.service = service;
+    }
+
+    @Scheduled(fixedRate = 5000) // check every 5 sec
+    public void readNewLogs() {
+        try {
+            Path path = Paths.get(LOG_FILE_PATH);
+            if (!Files.exists(path)) {
+                System.out.println("Log file not found: " + LOG_FILE_PATH);
+                return;
+            }
+
+            // Read the file as bytes
+            byte[] fileBytes = Files.readAllBytes(path);
+            String content = new String(fileBytes);
+
+            // Split lines
+            String[] lines = content.split("\\R");
+
+            // Process only new lines
+            for (int i = (int) lastKnownPosition; i < lines.length; i++) {
+                parseAndSave(lines[i]);
+            }
+
+            lastKnownPosition = lines.length; // update pointer
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void parseAndSave(String line) {
+        try {
+            // Format: ERROR 2025-09-10 10:12:35 /api/data Timeout after 5000ms
+            String[] parts = line.split(" ", 5);
+            if (parts.length < 5) return;
+
+            String level = parts[0];
+            String timestampStr = parts[1] + " " + parts[2];
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            LocalDateTime timestamp = LocalDateTime.parse(timestampStr, formatter);
+
+            String endpoint = parts[3];
+            String message = parts[4];
+
+            long latency = 0;
+            if (message.contains("processed in")) {
+                latency = Long.parseLong(message.replaceAll("[^0-9]", ""));
+            }
+
+            LogEntry log = new LogEntry();
+            log.setLevel(level);
+            log.setTimestamp(timestamp);
+            log.setEndpoint(endpoint);
+            log.setMessage(message);
+            log.setLatency(latency);
+
+            service.saveLog(log);
+
+        } catch (Exception e) {
+            System.out.println("Failed to parse line: " + line);
+        }
+    }
+}

--- a/src/main/java/com/harshal/logs/log_processor/ingest/LogGenerator.java
+++ b/src/main/java/com/harshal/logs/log_processor/ingest/LogGenerator.java
@@ -1,0 +1,33 @@
+package com.harshal.logs.log_processor.ingest;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.harshal.logs.log_processor.model.LogEntry;
+import com.harshal.logs.log_processor.service.LogService;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Component
+public class LogGenerator {
+    private final LogService service;
+    private final Random random = new Random();
+
+    public LogGenerator(LogService service) {
+        this.service = service;
+    }
+
+    @Scheduled(fixedRate = 5000) // every 5 seconds
+    public void generateLog() {
+        LogEntry log = new LogEntry();
+        log.setLevel(random.nextBoolean() ? "INFO" : "ERROR");
+        log.setEndpoint(random.nextBoolean() ? "/api/login" : "/api/data");
+        log.setLatency(50 + random.nextInt(500));
+        log.setMessage("Simulated log entry");
+        log.setTimestamp(LocalDateTime.now());
+
+        service.saveLog(log);
+        System.out.println("Generated log: " + log);
+    }
+}

--- a/src/main/java/com/harshal/logs/log_processor/ingest/LogProducer.java
+++ b/src/main/java/com/harshal/logs/log_processor/ingest/LogProducer.java
@@ -1,5 +1,0 @@
-package com.harshal.logs.log_processor.ingest;
-
-public class LogProducer {
-
-}

--- a/src/main/java/com/harshal/logs/log_processor/model/LogEntry.java
+++ b/src/main/java/com/harshal/logs/log_processor/model/LogEntry.java
@@ -1,0 +1,77 @@
+package com.harshal.logs.log_processor.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "logs")
+
+public class LogEntry {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String level;     // e.g., ERROR, INFO
+    private String endpoint;  // e.g., /api/login
+    private long latency;     // request time in ms
+    private String message;   // log message
+    private LocalDateTime timestamp; // 👈 use LocalDateTime instead of String
+	public Long getId() {
+		return id;
+	}
+	
+	
+	
+	public LogEntry() {
+		super();
+	}
+
+	public LogEntry(Long id, String level, String endpoint, long latency, String message, LocalDateTime timestamp) {
+		super();
+		this.id = id;
+		this.level = level;
+		this.endpoint = endpoint;
+		this.latency = latency;
+		this.message = message;
+		this.timestamp = timestamp;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+	public String getLevel() {
+		return level;
+	}
+	public void setLevel(String level) {
+		this.level = level;
+	}
+	public String getEndpoint() {
+		return endpoint;
+	}
+	public void setEndpoint(String endpoint) {
+		this.endpoint = endpoint;
+	}
+	public long getLatency() {
+		return latency;
+	}
+	public void setLatency(long latency) {
+		this.latency = latency;
+	}
+	public String getMessage() {
+		return message;
+	}
+	public void setMessage(String message) {
+		this.message = message;
+	}
+	public LocalDateTime getTimestamp() {
+		return timestamp;
+	}
+	public void setTimestamp(LocalDateTime timestamp) {
+		this.timestamp = timestamp;
+	}
+}

--- a/src/main/java/com/harshal/logs/log_processor/model/LogEvent.java
+++ b/src/main/java/com/harshal/logs/log_processor/model/LogEvent.java
@@ -1,5 +1,0 @@
-package com.harshal.logs.log_processor.model;
-
-public class LogEvent {
-
-}

--- a/src/main/java/com/harshal/logs/log_processor/repository/LogEntryRepository.java
+++ b/src/main/java/com/harshal/logs/log_processor/repository/LogEntryRepository.java
@@ -1,0 +1,17 @@
+package com.harshal.logs.log_processor.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.harshal.logs.log_processor.model.LogEntry;
+
+@Repository
+public interface LogEntryRepository extends JpaRepository<LogEntry, Long> {
+    // Later we can add custom queries like:
+    // List<LogEntry> findByLevel(String level);
+    List<LogEntry> findByTimestampAfter(LocalDateTime after);
+
+}

--- a/src/main/java/com/harshal/logs/log_processor/service/IngestionService.java
+++ b/src/main/java/com/harshal/logs/log_processor/service/IngestionService.java
@@ -1,5 +1,0 @@
-package com.harshal.logs.log_processor.service;
-
-public class IngestionService {
-
-}

--- a/src/main/java/com/harshal/logs/log_processor/service/LogService.java
+++ b/src/main/java/com/harshal/logs/log_processor/service/LogService.java
@@ -1,0 +1,107 @@
+package com.harshal.logs.log_processor.service;
+
+import org.springframework.stereotype.Service;
+
+import com.harshal.logs.log_processor.model.LogEntry;
+import com.harshal.logs.log_processor.repository.LogEntryRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class LogService {
+    private final LogEntryRepository repository;
+
+    public LogService(LogEntryRepository repository) {
+        this.repository = repository;
+    }
+
+    public LogEntry saveLog(LogEntry log) {
+        return repository.save(log);
+    }
+
+    public List<LogEntry> getAllLogs() {
+        return repository.findAll();
+    }
+    
+    public long countErrors() {
+        return repository.findAll().stream()
+                .filter(log -> "ERROR".equalsIgnoreCase(log.getLevel()))
+                .count();
+    }
+    
+    public double errorRate() {
+        long total = repository.count();
+        if (total == 0) return 0.0;
+        return (countErrors() * 100.0) / total;
+    }
+    
+
+    public double averageLatency() {
+        return repository.findAll().stream()
+                .mapToLong(LogEntry::getLatency)
+                .average()
+                .orElse(0.0);
+    }
+    
+
+    public Map<String, Long> topEndpoints() {
+        return repository.findAll().stream()
+                .collect(Collectors.groupingBy(LogEntry::getEndpoint, Collectors.counting()));
+    }
+
+    public Map<String, Long> logLevelsCount() {
+        return repository.findAll().stream()
+                .collect(Collectors.groupingBy(LogEntry::getLevel, Collectors.counting()));
+    }
+
+    
+    public List<LogEntry> getLogsAfterMinutes(int minutes) {
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(minutes);
+        return repository.findByTimestampAfter(cutoff);
+    }
+
+    public Map<String, Object> errorStatsInLastMinutes(int minutes) {
+        List<LogEntry> recentLogs = getLogsAfterMinutes(minutes);
+        if (recentLogs.isEmpty()) {
+            return Map.of("minutes", minutes, "totalRequests", 0, "errorCount", 0, "errorRate", 0.0);
+        }
+
+        long errors = recentLogs.stream()
+                .filter(log -> "ERROR".equalsIgnoreCase(log.getLevel()))
+                .count();
+
+        return Map.of(
+                "minutes", minutes,
+                "totalRequests", recentLogs.size(),
+                "errorCount", errors,
+                "errorRate", (errors * 100.0) / recentLogs.size()
+        );
+    }
+    
+    public Map<String, Object> latencyStatsInLastMinutes(int minutes) {
+        List<LogEntry> recentLogs = getLogsAfterMinutes(minutes);
+        if (recentLogs.isEmpty()) {
+            return Map.of("minutes", minutes, "averageLatency", 0.0);
+        }
+
+        double avgLatency = recentLogs.stream()
+                .mapToLong(LogEntry::getLatency)
+                .average()
+                .orElse(0.0);
+
+        return Map.of(
+                "minutes", minutes,
+                "averageLatency", avgLatency
+        );
+    }
+
+    public Map<String, Long> endpointsInLastMinutes(int minutes) {
+        List<LogEntry> recentLogs = getLogsAfterMinutes(minutes);
+        return recentLogs.stream()
+                .collect(Collectors.groupingBy(LogEntry::getEndpoint, Collectors.counting()));
+    }
+
+}

--- a/src/main/java/com/harshal/logs/log_processor/web/LogController.java
+++ b/src/main/java/com/harshal/logs/log_processor/web/LogController.java
@@ -1,0 +1,31 @@
+package com.harshal.logs.log_processor.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.harshal.logs.log_processor.model.LogEntry;
+import com.harshal.logs.log_processor.service.LogService;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/logs")
+public class LogController {
+    private final LogService service;
+
+    public LogController(LogService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public LogEntry createLog(@RequestBody LogEntry log) {
+        return service.saveLog(log);
+    }
+
+    @GetMapping
+    public List<LogEntry> getLogs() {
+        return service.getAllLogs();
+    }
+}

--- a/src/main/java/com/harshal/logs/log_processor/web/LogStatsController.java
+++ b/src/main/java/com/harshal/logs/log_processor/web/LogStatsController.java
@@ -1,0 +1,65 @@
+package com.harshal.logs.log_processor.web;
+
+import org.springframework.web.bind.annotation.*;
+
+import com.harshal.logs.log_processor.model.LogEntry;
+import com.harshal.logs.log_processor.service.LogService;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/stats")
+public class LogStatsController {
+    private final LogService service;
+
+    public LogStatsController(LogService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/errors")
+    public Map<String, Object> getErrorStats() {
+        return Map.of(
+                "errorCount", service.countErrors(),
+                "errorRate", service.errorRate()
+        );
+    }
+
+    @GetMapping("/latency")
+    public Map<String, Object> getLatencyStats() {
+        return Map.of("averageLatency", service.averageLatency());
+    }
+    
+    @GetMapping("/endpoints")
+    public Map<String, Long> getTopEndpoints() {
+        return service.topEndpoints();
+    }
+
+    @GetMapping("/levels")
+    public Map<String, Long> getLogLevels() {
+        return service.logLevelsCount();
+    }
+    
+    @GetMapping("/errors/recent")
+    public Map<String, Object> getRecentErrorStats(@RequestParam(defaultValue = "1") int minutes) {
+        return service.errorStatsInLastMinutes(minutes);
+    }
+
+
+    @GetMapping("/logs/recent")
+    public List<LogEntry> getRecentLogs(@RequestParam(defaultValue = "1") int minutes) {
+        return service.getLogsAfterMinutes(minutes);
+    }
+    
+    @GetMapping("/latency/recent")
+    public Map<String, Object> getRecentLatency(@RequestParam(defaultValue = "1") int minutes) {
+        return service.latencyStatsInLastMinutes(minutes);
+    }
+
+    @GetMapping("/endpoints/recent")
+    public Map<String, Long> getRecentEndpoints(@RequestParam(defaultValue = "1") int minutes) {
+        return service.endpointsInLastMinutes(minutes);
+    }
+
+
+}

--- a/src/main/java/com/harshal/logs/log_processor/web/RestControllers.java
+++ b/src/main/java/com/harshal/logs/log_processor/web/RestControllers.java
@@ -1,5 +1,0 @@
-package com.harshal.logs.log_processor.web;
-
-public class RestControllers {
-
-}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
-spring.application.name=Log Processor
+spring.datasource.url=jdbc:mysql://localhost:3306/logsdb
+spring.datasource.username=root
+spring.datasource.password=harshal25
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/static/dashboard.html
+++ b/src/main/resources/static/dashboard.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Log Processing Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 20px;
+      background: #f9f9f9;
+    }
+    h1 {
+      text-align: center;
+      margin-bottom: 30px;
+    }
+    .chart-container {
+      width: 600px;
+      margin: 20px auto;
+      background: white;
+      padding: 20px;
+      border-radius: 12px;
+      box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    }
+    .controls {
+      text-align: center;
+      margin-bottom: 20px;
+    }
+    select {
+      padding: 8px 12px;
+      font-size: 14px;
+      border-radius: 6px;
+    }
+  </style>
+</head>
+<body>
+  <h1>📊 Real-time Log Dashboard</h1>
+
+  <div class="controls">
+    <label for="timeRange">Time Range: </label>
+    <select id="timeRange" onchange="fetchData()">
+      <option value="1">Last 1 Minute</option>
+      <option value="5">Last 5 Minutes</option>
+      <option value="10">Last 10 Minutes</option>
+    </select>
+  </div>
+
+  <div class="chart-container">
+    <canvas id="errorChart"></canvas>
+  </div>
+
+  <div class="chart-container">
+    <canvas id="latencyChart"></canvas>
+  </div>
+
+  <div class="chart-container">
+    <canvas id="endpointChart"></canvas>
+  </div>
+
+  <script>
+    let errorChart, latencyChart, endpointChart;
+
+	async function fetchData() {
+	  const minutes = document.getElementById("timeRange").value;
+	
+	  const errors = await fetch(`/api/stats/errors/recent?minutes=${minutes}`).then(res => res.json());
+	  const latency = await fetch(`/api/stats/latency/recent?minutes=${minutes}`).then(res => res.json());
+	  const endpoints = await fetch(`/api/stats/endpoints/recent?minutes=${minutes}`).then(res => res.json());
+	  const levels = await fetch(`/api/stats/levels`).then(res => res.json());
+	
+	  renderCharts(errors, latency, endpoints, levels);
+	}
+
+	function renderCharts(errors, latency, endpoints, levels) {
+	  if (errorChart) errorChart.destroy();
+	  if (latencyChart) latencyChart.destroy();
+	  if (endpointChart) endpointChart.destroy();
+	
+	  // Error Pie Chart
+	  errorChart = new Chart(document.getElementById("errorChart"), {
+	    type: "pie",
+	    data: {
+	      labels: ["Errors", "Success"],
+	      datasets: [{
+	        data: [errors.errorCount, errors.totalRequests - errors.errorCount],
+	        backgroundColor: ["#e74c3c", "#2ecc71"]
+	      }]
+	    },
+	    options: {
+	      plugins: {
+	        title: {
+	          display: true,
+	          text: `Error Rate (last ${errors.minutes} min) = ${errors.errorRate.toFixed(2)}%`
+	        }
+	      }
+	    }
+	  });
+
+	   // Latency Chart
+	  latencyChart = new Chart(document.getElementById("latencyChart"), {
+	    type: "bar",
+	    data: {
+	      labels: [`Last ${latency.minutes} min`],
+	      datasets: [{
+	        label: "Avg Latency (ms)",
+	        data: [latency.averageLatency],
+	        backgroundColor: ["#3498db"]
+	      }]
+	    }
+	  });
+
+	  // Endpoint Usage Chart
+	  endpointChart = new Chart(document.getElementById("endpointChart"), {
+	    type: "bar",
+	    data: {
+	      labels: Object.keys(endpoints),
+	      datasets: [{
+	        label: "API Calls",
+	        data: Object.values(endpoints),
+	        backgroundColor: "#9b59b6"
+	      }]
+	    },
+	    options: {
+	      indexAxis: "y",
+	      plugins: {
+	        title: {
+	          display: true,
+	          text: `Top Endpoints (last ${errors.minutes} min)`
+	        }
+	      }
+	    }
+	  });
+    }
+
+    fetchData();
+    setInterval(fetchData, 5000); // auto-refresh every 5s
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- Implemented service methods to calculate average latency and endpoint usage within the last X minutes
- Added new REST endpoints: /latency/recent and /endpoints/recent
- Updated dashboard.js to fetch and display latency + endpoint stats based on time range
- Improved charts to dynamically update according to dropdown filter